### PR TITLE
Fix green-20220302 import without websocket helpers

### DIFF
--- a/green-20220302/alibabacloud_green20220302/client.py
+++ b/green-20220302/alibabacloud_green20220302/client.py
@@ -8,12 +8,18 @@ from alibabacloud_green20220302 import models as main_models
 from alibabacloud_tea_openapi import utils_models as open_api_util_models
 from alibabacloud_tea_openapi.client import Client as OpenApiClient
 from alibabacloud_tea_openapi.utils import Utils
-from alibabacloud_tea_openapi.websocketUtils import Client as WebSocketUtilsClient
 from darabonba.core import DaraCore as DaraCore
 from darabonba.runtime import RuntimeOptions
 
 """
 """
+
+def _create_web_socket_client(web_socket_client_config):
+    from alibabacloud_tea_openapi.websocketUtils import Client as WebSocketUtilsClient
+
+    return WebSocketUtilsClient.create_web_socket_client(web_socket_client_config)
+
+
 class Client(OpenApiClient):
 
     def __init__(
@@ -1481,7 +1487,7 @@ class Client(OpenApiClient):
         res = main_models.MultiModalGuardWsResponse()
         tmp = self.call_api(params, req, runtime)
         if not DaraCore.is_null(tmp.get('webSocketClient')):
-            res.web_socket_client = WebSocketUtilsClient.create_web_socket_client(tmp.get('webSocketClient'))
+            res.web_socket_client = _create_web_socket_client(tmp.get('webSocketClient'))
         return res
 
     async def multi_modal_guard_ws_with_options_async(
@@ -1509,7 +1515,7 @@ class Client(OpenApiClient):
         res = main_models.MultiModalGuardWsResponse()
         tmp = await self.call_api_async(params, req, runtime)
         if not DaraCore.is_null(tmp.get('webSocketClient')):
-            res.web_socket_client = WebSocketUtilsClient.create_web_socket_client(tmp.get('webSocketClient'))
+            res.web_socket_client = _create_web_socket_client(tmp.get('webSocketClient'))
         return res
 
     def multi_modal_guard_ws(

--- a/green-20220302/alibabacloud_green20220302/models/_multi_modal_guard_ws_response.py
+++ b/green-20220302/alibabacloud_green20220302/models/_multi_modal_guard_ws_response.py
@@ -2,13 +2,18 @@
 # This file is auto-generated, don't edit it. Thanks.
 from __future__ import annotations
 
-from alibabacloud_tea_openapi import websocketUtils_models as web_socket_utils_models
 from darabonba.model import DaraModel
+
+
+def _get_web_socket_utils_models():
+    from alibabacloud_tea_openapi import websocketUtils_models as web_socket_utils_models
+
+    return web_socket_utils_models
 
 class MultiModalGuardWsResponse(DaraModel):
     def __init__(
         self,
-        web_socket_client: web_socket_utils_models.WebSocketClient = None,
+        web_socket_client = None,
     ):
         self.web_socket_client = web_socket_client
 
@@ -28,8 +33,8 @@ class MultiModalGuardWsResponse(DaraModel):
     def from_map(self, m: dict = None):
         m = m or dict()
         if m.get('webSocketClient') is not None:
+            web_socket_utils_models = _get_web_socket_utils_models()
             temp_model = web_socket_utils_models.WebSocketClient()
             self.web_socket_client = temp_model.from_map(m.get('webSocketClient'))
 
         return self
-

--- a/green-20220302/tests/test_import.py
+++ b/green-20220302/tests/test_import.py
@@ -1,0 +1,6 @@
+def test_green_20220302_imports_with_current_tea_openapi():
+    from alibabacloud_green20220302 import models
+    from alibabacloud_green20220302.client import Client
+
+    assert models.TextModerationRequest is not None
+    assert Client is not None


### PR DESCRIPTION
## Summary
- delay websocket helper imports in green-20220302 so importing the package and non-websocket APIs does not fail when alibabacloud-tea-openapi lacks websocketUtils modules
- keep MultiModalGuardWs websocket helper loading at the call/from_map site where it is actually needed
- add a regression test covering package import with the current alibabacloud-tea-openapi dependency

## Reproduction
With alibabacloud-green20220302 3.4.0 and alibabacloud-tea-openapi 0.4.4, this currently fails during import:

```python
from alibabacloud_green20220302 import models
from alibabacloud_green20220302.client import Client
```

The failure is caused by generated MultiModalGuardWs code importing `alibabacloud_tea_openapi.websocketUtils_models` and `alibabacloud_tea_openapi.websocketUtils` at module import time. Those modules are not present in the currently released alibabacloud-tea-openapi 0.4.4 package.

This PR does not claim MultiModalGuardWs works without the websocket helper support. It only avoids breaking unrelated APIs such as TextModeration at import time.

## Test
- `cd green-20220302 && /tmp/green-20220302-pr-venv/bin/python -m pytest tests/test_import.py -q`
- `cd green-20220302 && /tmp/green-20220302-pr-venv/bin/python -m compileall -q alibabacloud_green20220302`
- `git diff --check`